### PR TITLE
Add full FocusPad productivity experience

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,14 @@
-from fastapi import FastAPI
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from itertools import count
+from typing import Literal
+
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, Field
+
 
 app = FastAPI(title="FocusPad API")
 
@@ -16,6 +25,190 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+class TaskBase(BaseModel):
+    title: str = Field(..., min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=1_000)
+    priority: Literal["low", "medium", "high"] = "medium"
+    estimated_minutes: int | None = Field(
+        default=None,
+        ge=1,
+        le=720,
+        description="Estimated focus time for the task in minutes.",
+    )
+
+
+class Task(TaskBase):
+    id: int
+    completed: bool = False
+    created_at: datetime
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(BaseModel):
+    title: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = Field(default=None, max_length=1_000)
+    priority: Literal["low", "medium", "high"] | None = None
+    estimated_minutes: int | None = Field(default=None, ge=1, le=720)
+    completed: bool | None = None
+
+
+class FocusSession(BaseModel):
+    id: int
+    task_id: int | None = None
+    seconds: int = Field(ge=60, le=12 * 60 * 60)
+    note: str | None = Field(default=None, max_length=240)
+    created_at: datetime
+
+
+class FocusSessionCreate(BaseModel):
+    task_id: int | None = None
+    seconds: int = Field(ge=60, le=12 * 60 * 60)
+    note: str | None = Field(default=None, max_length=240)
+
+
+class StatsResponse(BaseModel):
+    total_sessions: int
+    total_focus_minutes: int
+    average_session_minutes: float
+    longest_session_minutes: float
+    focus_days: int
+    completed_tasks: int
+    active_tasks: int
+
+
+_task_store: dict[int, Task] = {}
+_session_store: dict[int, FocusSession] = {}
+_task_id_counter = count(start=1)
+_session_id_counter = count(start=1)
+
+
+def _now() -> datetime:
+    return datetime.now(UTC)
+
+
+def reset_state() -> None:
+    """Reset the in-memory data stores.
+
+    The tests call this helper to make sure each test runs with a predictable
+    set of data. While the production app never invokes it, keeping it part of
+    the public module API makes it straightforward for other modules (such as
+    tests) to import and call it.
+    """
+
+    _task_store.clear()
+    _session_store.clear()
+
+    global _task_id_counter, _session_id_counter
+
+    _task_id_counter = count(start=1)
+    _session_id_counter = count(start=1)
+
+
 @app.get("/ping")
-async def ping():
+async def ping() -> dict[str, str]:
     return {"msg": "pong"}
+
+
+@app.get("/tasks", response_model=list[Task])
+async def list_tasks() -> list[Task]:
+    tasks = sorted(
+        _task_store.values(),
+        key=lambda task: (task.completed, -task.created_at.timestamp()),
+    )
+    return [task.model_copy() for task in tasks]
+
+
+@app.post("/tasks", response_model=Task, status_code=201)
+async def create_task(payload: TaskCreate) -> Task:
+    task_id = next(_task_id_counter)
+    task = Task(
+        id=task_id,
+        completed=False,
+        created_at=_now(),
+        **payload.model_dump(),
+    )
+    _task_store[task_id] = task
+    return task.model_copy()
+
+
+@app.patch("/tasks/{task_id}", response_model=Task)
+async def update_task(task_id: int, payload: TaskUpdate) -> Task:
+    try:
+        stored_task = _task_store[task_id]
+    except KeyError as exc:  # pragma: no cover - defensive, but tested indirectly
+        raise HTTPException(status_code=404, detail="Task not found") from exc
+
+    updated = stored_task.model_copy(update=payload.model_dump(exclude_unset=True))
+    _task_store[task_id] = updated
+    return updated.model_copy()
+
+
+@app.delete("/tasks/{task_id}", status_code=204, response_class=Response)
+async def delete_task(task_id: int) -> Response:
+    if task_id not in _task_store:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    _task_store.pop(task_id)
+    return Response(status_code=204)
+
+
+@app.get("/sessions", response_model=list[FocusSession])
+async def list_sessions() -> list[FocusSession]:
+    sessions = sorted(
+        _session_store.values(),
+        key=lambda session: session.created_at,
+        reverse=True,
+    )
+    return [session.model_copy() for session in sessions]
+
+
+@app.post("/sessions", response_model=FocusSession, status_code=201)
+async def create_session(payload: FocusSessionCreate) -> FocusSession:
+    if payload.task_id is not None and payload.task_id not in _task_store:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    session_id = next(_session_id_counter)
+    session = FocusSession(
+        id=session_id,
+        created_at=_now(),
+        **payload.model_dump(),
+    )
+    _session_store[session_id] = session
+    return session.model_copy()
+
+
+def _calculate_focus_days(sessions: Iterable[FocusSession]) -> int:
+    return len({session.created_at.date() for session in sessions})
+
+
+def _calculate_longest_session_minutes(sessions: Iterable[FocusSession]) -> float:
+    try:
+        longest_seconds = max(session.seconds for session in sessions)
+    except ValueError:
+        return 0.0
+    return round(longest_seconds / 60, 1)
+
+
+@app.get("/stats", response_model=StatsResponse)
+async def get_stats() -> StatsResponse:
+    sessions = list(_session_store.values())
+    total_sessions = len(sessions)
+    total_focus_seconds = sum(session.seconds for session in sessions)
+    total_minutes = total_focus_seconds // 60
+    average_minutes = round(
+        (total_focus_seconds / 60) / total_sessions, 1
+    ) if total_sessions else 0.0
+
+    return StatsResponse(
+        total_sessions=total_sessions,
+        total_focus_minutes=total_minutes,
+        average_session_minutes=average_minutes,
+        longest_session_minutes=_calculate_longest_session_minutes(sessions),
+        focus_days=_calculate_focus_days(sessions),
+        completed_tasks=sum(task.completed for task in _task_store.values()),
+        active_tasks=sum(not task.completed for task in _task_store.values()),
+    )

--- a/backend/tests/test_focuspad.py
+++ b/backend/tests/test_focuspad.py
@@ -1,0 +1,90 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.main import app, reset_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_state() -> Iterator[None]:
+    reset_state()
+    yield
+    reset_state()
+
+
+client = TestClient(app)
+
+
+def test_create_and_list_tasks() -> None:
+    response = client.post(
+        "/tasks",
+        json={"title": "Write weekly report", "priority": "high", "estimated_minutes": 45},
+    )
+    assert response.status_code == 201
+
+    created = response.json()
+    assert created["title"] == "Write weekly report"
+    assert created["priority"] == "high"
+    assert created["completed"] is False
+    assert created["estimated_minutes"] == 45
+
+    list_response = client.get("/tasks")
+    assert list_response.status_code == 200
+
+    tasks = list_response.json()
+    assert len(tasks) == 1
+    assert tasks[0]["id"] == created["id"]
+
+
+def test_update_and_delete_task() -> None:
+    created = client.post("/tasks", json={"title": "Deep work block"}).json()
+    task_id = created["id"]
+
+    update = client.patch(
+        f"/tasks/{task_id}", json={"completed": True, "priority": "low", "estimated_minutes": None}
+    )
+    assert update.status_code == 200
+
+    updated_task = update.json()
+    assert updated_task["completed"] is True
+    assert updated_task["priority"] == "low"
+    assert updated_task["estimated_minutes"] is None
+
+    delete_response = client.delete(f"/tasks/{task_id}")
+    assert delete_response.status_code == 204
+
+    list_after_delete = client.get("/tasks")
+    assert list_after_delete.json() == []
+
+
+def test_create_session_and_stats() -> None:
+    task = client.post("/tasks", json={"title": "Study algorithms"}).json()
+
+    session_response = client.post(
+        "/sessions",
+        json={"task_id": task["id"], "seconds": 1_500, "note": "Pomodoro"},
+    )
+    assert session_response.status_code == 201
+
+    session = session_response.json()
+    assert session["seconds"] == 1_500
+    assert session["task_id"] == task["id"]
+    assert session["note"] == "Pomodoro"
+
+    stats_response = client.get("/stats")
+    assert stats_response.status_code == 200
+
+    stats = stats_response.json()
+    assert stats["total_sessions"] == 1
+    assert stats["total_focus_minutes"] == 25
+    assert stats["average_session_minutes"] == pytest.approx(25)
+    assert stats["longest_session_minutes"] == pytest.approx(25)
+    assert stats["focus_days"] == 1
+    assert stats["completed_tasks"] == 0
+    assert stats["active_tasks"] == 1
+
+
+def test_session_requires_existing_task() -> None:
+    response = client.post("/sessions", json={"task_id": 99, "seconds": 1_200})
+    assert response.status_code == 404

--- a/frontend/client/src/App.css
+++ b/frontend/client/src/App.css
@@ -1,42 +1,490 @@
-#root {
-  max-width: 1280px;
+.app-shell {
+  max-width: 1180px;
   margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 2.75rem;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+
+.app-header p {
+  margin: 0.4rem 0 0;
+  max-width: 520px;
+  color: #475569;
+}
+
+.panels-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  background-color: #ffffff;
+  border-radius: 24px;
   padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 22px 45px -30px rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.1);
+}
+
+.panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.45rem;
+  color: #0f172a;
+}
+
+.panel-subtitle {
+  margin: 0.25rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
+}
+
+.banner {
+  border-radius: 16px;
+  padding: 0.85rem 1.2rem;
+  font-weight: 600;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.05);
+}
+
+.banner.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.banner.success {
+  background: #dcfce7;
+  color: #166534;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background-color 0.2s ease;
+}
+
+.button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  box-shadow: 0 18px 36px -20px rgba(99, 102, 241, 0.7);
+}
+
+.button.primary:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 20px 40px -20px rgba(99, 102, 241, 0.75);
+}
+
+.button.secondary {
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.button.secondary:hover:not(:disabled) {
+  background: #cbd5f5;
+}
+
+.button.ghost {
+  background: transparent;
+  color: #4f46e5;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+}
+
+.button.ghost:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.08);
+}
+
+.button.small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.85rem;
+}
+
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  text-align: left;
+}
+
+.field label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #64748b;
+}
+
+.field input,
+.field textarea,
+.field select {
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 0.65rem 0.8rem;
+  background-color: #f8fafc;
+  font: inherit;
+  color: #0f172a;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.field textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+  background-color: #ffffff;
+}
+
+.task-form-footer {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.field.compact {
+  min-width: 140px;
+  flex: 1 1 120px;
+}
+
+.task-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.task-card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1.1rem;
+  padding: 1.1rem 1.35rem;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: #f8fafc;
+  transition: transform 0.18s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.task-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: 0 16px 32px -28px rgba(79, 70, 229, 0.5);
+}
+
+.task-card.active {
+  border-color: rgba(99, 102, 241, 0.45);
+  background: #eef2ff;
+}
+
+.task-card.completed {
+  opacity: 0.7;
+  background: #f1f5f9;
+}
+
+.task-check {
+  width: 1.25rem;
+  height: 1.25rem;
+  border-radius: 50%;
+  border: 2px solid rgba(99, 102, 241, 0.4);
+  background-color: #ffffff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  margin-top: 0.35rem;
+  transition: all 0.15s ease;
+}
+
+.task-card.completed .task-check {
+  background-color: #34d399;
+  border-color: #34d399;
+}
+
+.task-check::after {
+  content: "";
+  width: 0.45rem;
+  height: 0.75rem;
+  border: 2px solid #ffffff;
+  border-left: none;
+  border-top: none;
+  transform: rotate(45deg) scale(0);
+  transition: transform 0.15s ease;
+}
+
+.task-card.completed .task-check::after {
+  transform: rotate(45deg) scale(1);
+}
+
+.task-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  cursor: pointer;
+}
+
+.task-title-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.task-title-row h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.badge.low {
+  background: #ecfdf3;
+  color: #15803d;
+}
+
+.badge.medium {
+  background: #eef2ff;
+  color: #4f46e5;
+}
+
+.badge.high {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.task-notes {
+  margin: 0;
+  color: #475569;
+  line-height: 1.45;
+}
+
+.task-meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.task-meta .button {
+  align-self: flex-start;
+}
+
+.empty {
+  margin: 0;
+  color: #94a3b8;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.timer-active,
+.timer-setup {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  align-items: stretch;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.timer-active h3 {
+  margin: 0;
+  font-size: 1.25rem;
+  text-align: center;
+  color: #312e81;
+}
+
+.timer-display {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  font-weight: 700;
+  text-align: center;
+  color: #111827;
+  letter-spacing: 0.05em;
+}
+
+.progress-track {
+  height: 0.55rem;
+  border-radius: 999px;
+  background: #e2e8f0;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  transition: width 0.35s ease;
+}
+
+.timer-actions {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.timer-duration {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.duration-buttons {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.timer-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: #64748b;
+  text-align: center;
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1rem;
+}
+
+.stat {
+  background: #f8fafc;
+  border-radius: 18px;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.stat-label {
+  color: #64748b;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.stat-value {
+  font-size: 2rem;
+  margin: 0;
+  color: #1e293b;
+  font-weight: 700;
+}
+
+.stat-hint {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.session-list h3 {
+  margin: 0 0 0.75rem;
+  color: #0f172a;
+}
+
+.session-list ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.session-list li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.session-list li:last-child {
+  border-bottom: none;
+}
+
+.session-duration {
+  font-weight: 600;
+  color: #4f46e5;
+  margin-right: 0.5rem;
+}
+
+.session-task {
+  color: #1e293b;
+}
+
+.session-time {
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .app-shell {
+    padding: 2.5rem 1.25rem 3rem;
   }
-  to {
-    transform: rotate(360deg);
+
+  .panel {
+    padding: 1.6rem;
   }
-}
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+  .task-form-footer {
+    flex-direction: column;
+    align-items: stretch;
   }
-}
 
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  .timer-actions {
+    flex-direction: column;
+  }
 }

--- a/frontend/client/src/App.tsx
+++ b/frontend/client/src/App.tsx
@@ -1,18 +1,650 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { ChangeEvent, FormEvent, JSX } from "react";
+import "./App.css";
 
-export default function App() {
-  const [msg, setMsg] = useState("loading...");
+type TaskPriority = "low" | "medium" | "high";
 
-  useEffect(() => {
-    fetch("http://localhost:8000/ping")
-      .then((r) => r.json())
-      .then((d) => setMsg(d.msg))
-      .catch(() => setMsg("error"));
+type Task = {
+  id: number;
+  title: string;
+  description: string | null;
+  priority: TaskPriority;
+  estimated_minutes: number | null;
+  completed: boolean;
+  created_at: string;
+};
+
+type FocusSession = {
+  id: number;
+  task_id: number | null;
+  seconds: number;
+  note: string | null;
+  created_at: string;
+};
+
+type Stats = {
+  total_sessions: number;
+  total_focus_minutes: number;
+  average_session_minutes: number;
+  longest_session_minutes: number;
+  focus_days: number;
+  completed_tasks: number;
+  active_tasks: number;
+};
+
+type TaskFormState = {
+  title: string;
+  description: string;
+  estimatedMinutes: string;
+  priority: TaskPriority;
+};
+
+type TimerState = {
+  taskId: number | null;
+  label: string;
+  durationSeconds: number;
+  remainingSeconds: number;
+  running: boolean;
+};
+
+const API_BASE_URL =
+  (import.meta.env.VITE_API_BASE_URL as string | undefined) ?? "http://localhost:8000";
+const DEFAULT_TASK_FORM: TaskFormState = {
+  title: "",
+  description: "",
+  estimatedMinutes: "",
+  priority: "medium",
+};
+const MIN_SESSION_MINUTES = 5;
+const MAX_SESSION_MINUTES = 240;
+
+const formatTimer = (totalSeconds: number): string => {
+  const clamped = Math.max(0, totalSeconds);
+  const minutes = Math.floor(clamped / 60);
+  const seconds = clamped % 60;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+
+  if (hours > 0) {
+    return `${hours}:${remainingMinutes.toString().padStart(2, "0")}:${seconds
+      .toString()
+      .padStart(2, "0")}`;
+  }
+
+  return `${minutes.toString().padStart(2, "0")}:${seconds.toString().padStart(2, "0")}`;
+};
+
+const formatMinutesLabel = (minutes: number): string => {
+  if (minutes <= 0) {
+    return "0 min";
+  }
+  if (minutes < 60) {
+    return `${minutes} min`;
+  }
+  const hours = Math.floor(minutes / 60);
+  const remaining = minutes % 60;
+  if (remaining === 0) {
+    return `${hours} hr${hours > 1 ? "s" : ""}`;
+  }
+  return `${hours}h ${remaining}m`;
+};
+
+const formatSessionTimestamp = (iso: string): string => {
+  const timestamp = new Date(iso);
+  return timestamp.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+};
+
+export default function App(): JSX.Element {
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [sessions, setSessions] = useState<FocusSession[]>([]);
+  const [stats, setStats] = useState<Stats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastSessionMessage, setLastSessionMessage] = useState<string | null>(null);
+  const [taskForm, setTaskForm] = useState<TaskFormState>(() => ({ ...DEFAULT_TASK_FORM }));
+  const [selectedTaskId, setSelectedTaskId] = useState<number | null>(null);
+  const [customMinutes, setCustomMinutes] = useState<string>("25");
+  const [timerState, setTimerState] = useState<TimerState | null>(null);
+
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.id === selectedTaskId) ?? null,
+    [selectedTaskId, tasks],
+  );
+
+  const orderedTasks = useMemo(() => {
+    return tasks.slice().sort((a, b) => {
+      if (a.completed !== b.completed) {
+        return Number(a.completed) - Number(b.completed);
+      }
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+  }, [tasks]);
+
+  const recentSessions = useMemo(() => {
+    return sessions
+      .slice()
+      .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      .slice(0, 6);
+  }, [sessions]);
+
+  const request = useCallback(async (path: string, init?: RequestInit) => {
+    const requestConfig: RequestInit = {
+      ...init,
+      headers: {
+        Accept: "application/json",
+        ...(init?.body ? { "Content-Type": "application/json" } : {}),
+        ...(init?.headers ?? {}),
+      },
+    };
+
+    const response = await fetch(`${API_BASE_URL}${path}`, requestConfig);
+    if (!response.ok) {
+      const detail = await response.json().catch(() => null);
+      throw new Error(detail?.detail ?? `Request failed with status ${response.status}`);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    return response.json();
   }, []);
 
+  const loadEverything = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [tasksResponse, sessionsResponse, statsResponse] = await Promise.all([
+        request("/tasks"),
+        request("/sessions"),
+        request("/stats"),
+      ]);
+      setTasks(tasksResponse as Task[]);
+      setSessions(sessionsResponse as FocusSession[]);
+      setStats(statsResponse as Stats);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to reach the FocusPad API.");
+    } finally {
+      setLoading(false);
+    }
+  }, [request]);
+
+  useEffect(() => {
+    void loadEverything();
+  }, [loadEverything]);
+
+  useEffect(() => {
+    if (selectedTaskId && !tasks.some((task) => task.id === selectedTaskId)) {
+      setSelectedTaskId(null);
+    }
+  }, [selectedTaskId, tasks]);
+
+  const handleTaskFieldChange = (
+    field: keyof TaskFormState,
+  ) =>
+    (event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+      setTaskForm((prev) => ({ ...prev, [field]: event.target.value }));
+    };
+
+  const handleTaskSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedTitle = taskForm.title.trim();
+
+    if (!trimmedTitle) {
+      setError("Please provide a task title.");
+      return;
+    }
+
+    const estimated = Number(taskForm.estimatedMinutes);
+    const payload = {
+      title: trimmedTitle,
+      description: taskForm.description.trim() || null,
+      priority: taskForm.priority,
+      estimated_minutes: Number.isFinite(estimated) && estimated > 0 ? Math.round(estimated) : null,
+    };
+
+    try {
+      await request("/tasks", { method: "POST", body: JSON.stringify(payload) });
+      setTaskForm(() => ({ ...DEFAULT_TASK_FORM }));
+      setError(null);
+      await loadEverything();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to save the task.");
+    }
+  };
+
+  const handleToggleTask = async (task: Task) => {
+    try {
+      await request(`/tasks/${task.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ completed: !task.completed }),
+      });
+      await loadEverything();
+      setLastSessionMessage(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to update the task.");
+    }
+  };
+
+  const handleDeleteTask = async (taskId: number) => {
+    try {
+      await request(`/tasks/${taskId}`, { method: "DELETE" });
+      await loadEverything();
+      setLastSessionMessage(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to delete the task.");
+    }
+  };
+
+  const handleSelectTask = (taskId: number) => {
+    setSelectedTaskId((previous) => (previous === taskId ? null : taskId));
+    const chosen = tasks.find((task) => task.id === taskId);
+    if (chosen?.estimated_minutes) {
+      setCustomMinutes(String(chosen.estimated_minutes));
+    }
+    setLastSessionMessage(null);
+  };
+
+  const logSession = useCallback(
+    async (seconds: number, taskId: number | null, note: string) => {
+      try {
+        await request("/sessions", {
+          method: "POST",
+          body: JSON.stringify({ seconds, task_id: taskId, note }),
+        });
+        await loadEverything();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Unable to record the focus session.");
+      }
+    },
+    [loadEverything, request],
+  );
+
+  const handleStartTimer = () => {
+    const parsedMinutes = Number(customMinutes);
+    if (!Number.isFinite(parsedMinutes) || parsedMinutes <= 0) {
+      setError("Enter a focus duration greater than zero.");
+      return;
+    }
+
+    const clampedMinutes = Math.min(Math.max(Math.round(parsedMinutes), MIN_SESSION_MINUTES), MAX_SESSION_MINUTES);
+    const durationSeconds = clampedMinutes * 60;
+    const label = selectedTask?.title ?? "Custom focus";
+
+    setTimerState({
+      taskId: selectedTask?.id ?? null,
+      label,
+      durationSeconds,
+      remainingSeconds: durationSeconds,
+      running: true,
+    });
+    setCustomMinutes(String(clampedMinutes));
+    setLastSessionMessage(null);
+    setError(null);
+  };
+
+  const handleToggleTimer = () => {
+    setTimerState((previous) => (previous ? { ...previous, running: !previous.running } : previous));
+  };
+
+  const handleStopTimer = () => {
+    if (!timerState) {
+      return;
+    }
+
+    const snapshot = timerState;
+    setTimerState(null);
+
+    const elapsedSeconds = snapshot.durationSeconds - snapshot.remainingSeconds;
+    if (elapsedSeconds < 60) {
+      setLastSessionMessage("Sessions shorter than a minute aren't saved. Try a slightly longer block.");
+      return;
+    }
+
+    void (async () => {
+      await logSession(elapsedSeconds, snapshot.taskId, "Ended focus session early");
+      const minutes = Math.round(elapsedSeconds / 60);
+      setLastSessionMessage(
+        `Logged ${minutes} minute${minutes === 1 ? "" : "s"} of focus${
+          snapshot.taskId ? ` on "${snapshot.label}"` : ""
+        }.`,
+      );
+    })();
+  };
+
+  useEffect(() => {
+    if (!timerState?.running) {
+      return;
+    }
+
+    if (timerState.remainingSeconds <= 0) {
+      const finished = timerState;
+      setTimerState(null);
+      void (async () => {
+        await logSession(finished.durationSeconds, finished.taskId, "Completed focus session");
+        const minutes = Math.round(finished.durationSeconds / 60);
+        setLastSessionMessage(
+          `Completed a ${minutes}-minute session${finished.taskId ? ` on "${finished.label}"` : ""}. Nice work!`,
+        );
+      })();
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setTimerState((previous) =>
+        previous && previous.running
+          ? { ...previous, remainingSeconds: Math.max(previous.remainingSeconds - 1, 0) }
+          : previous,
+      );
+    }, 1_000);
+
+    return () => window.clearTimeout(timeout);
+  }, [logSession, timerState]);
+
+  const resolveTaskTitle = useCallback(
+    (taskId: number | null) => {
+      if (taskId === null) {
+        return "Unassigned focus";
+      }
+      return tasks.find((task) => task.id === taskId)?.title ?? "Completed task";
+    },
+    [tasks],
+  );
+
+  const timerProgress = useMemo(() => {
+    if (!timerState) {
+      return 0;
+    }
+    const elapsed = timerState.durationSeconds - timerState.remainingSeconds;
+    return Math.min(100, Math.max(0, Math.round((elapsed / timerState.durationSeconds) * 100)));
+  }, [timerState]);
+
   return (
-    <div style={{ fontFamily: "sans-serif", textAlign: "center", marginTop: 40 }}>
-      <h1>Hello – {msg}</h1>
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>FocusPad</h1>
+          <p>Organise tasks, run focused sessions, and keep track of meaningful progress.</p>
+        </div>
+        <button className="button ghost" type="button" onClick={() => loadEverything()} disabled={loading}>
+          Refresh data
+        </button>
+      </header>
+
+      {error ? (
+        <div className="banner error">{error}</div>
+      ) : null}
+
+      {lastSessionMessage ? <div className="banner success">{lastSessionMessage}</div> : null}
+
+      <div className="panels-grid">
+        <section className="panel tasks-panel">
+          <div className="panel-header">
+            <div>
+              <h2>Tasks</h2>
+              <p className="panel-subtitle">
+                {stats ? `${stats.active_tasks} active • ${stats.completed_tasks} completed` : "Plan your day"}
+              </p>
+            </div>
+          </div>
+
+          <form className="task-form" onSubmit={handleTaskSubmit}>
+            <div className="field">
+              <label htmlFor="task-title">Task title</label>
+              <input
+                id="task-title"
+                name="title"
+                placeholder="Write next blog post"
+                value={taskForm.title}
+                onChange={handleTaskFieldChange("title")}
+                required
+              />
+            </div>
+
+            <div className="field">
+              <label htmlFor="task-description">Notes</label>
+              <textarea
+                id="task-description"
+                name="description"
+                placeholder="Optional context to make getting started easier"
+                value={taskForm.description}
+                onChange={handleTaskFieldChange("description")}
+                rows={3}
+              />
+            </div>
+
+            <div className="task-form-footer">
+              <div className="field compact">
+                <label htmlFor="task-estimate">Est. minutes</label>
+                <input
+                  id="task-estimate"
+                  name="estimatedMinutes"
+                  type="number"
+                  min={5}
+                  max={720}
+                  placeholder="45"
+                  value={taskForm.estimatedMinutes}
+                  onChange={handleTaskFieldChange("estimatedMinutes")}
+                />
+              </div>
+
+              <div className="field compact">
+                <label htmlFor="task-priority">Priority</label>
+                <select
+                  id="task-priority"
+                  name="priority"
+                  value={taskForm.priority}
+                  onChange={handleTaskFieldChange("priority")}
+                >
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                </select>
+              </div>
+
+              <button className="button primary" type="submit">
+                Add task
+              </button>
+            </div>
+          </form>
+
+          <div className="task-list">
+            {loading ? (
+              <p className="empty">Loading tasks…</p>
+            ) : orderedTasks.length === 0 ? (
+              <p className="empty">Add your first task to start planning.</p>
+            ) : (
+              orderedTasks.map((task) => (
+                <article
+                  key={task.id}
+                  className={`task-card${task.completed ? " completed" : ""}${
+                    selectedTaskId === task.id ? " active" : ""
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="task-check"
+                    onClick={() => handleToggleTask(task)}
+                    aria-label={task.completed ? "Mark task as incomplete" : "Mark task as complete"}
+                  />
+
+                  <div className="task-content" onClick={() => handleSelectTask(task.id)}>
+                    <div className="task-title-row">
+                      <h3>{task.title}</h3>
+                      <span className={`badge ${task.priority}`}>{task.priority}</span>
+                    </div>
+                    {task.description ? <p className="task-notes">{task.description}</p> : null}
+                    <div className="task-meta">
+                      {task.estimated_minutes ? (
+                        <span>{formatMinutesLabel(task.estimated_minutes)}</span>
+                      ) : (
+                        <span>No estimate</span>
+                      )}
+                      <button
+                        className="button ghost small"
+                        type="button"
+                        onClick={() => handleDeleteTask(task.id)}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              ))
+            )}
+          </div>
+        </section>
+
+        <section className="panel timer-panel">
+          <div className="panel-header">
+            <div>
+              <h2>Focus timer</h2>
+              <p className="panel-subtitle">
+                {timerState ? `In session • ${timerProgress}% complete` : "Select a task or run a custom block"}
+              </p>
+            </div>
+          </div>
+
+          {timerState ? (
+            <div className="timer-active">
+              <h3>{timerState.label}</h3>
+              <div className="timer-display">{formatTimer(timerState.remainingSeconds)}</div>
+              <div className="progress-track" aria-hidden>
+                <div className="progress-fill" style={{ width: `${timerProgress}%` }} />
+              </div>
+              <div className="timer-actions">
+                <button className="button primary" type="button" onClick={handleToggleTimer}>
+                  {timerState.running ? "Pause" : "Resume"}
+                </button>
+                <button className="button secondary" type="button" onClick={handleStopTimer}>
+                  Finish early
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="timer-setup">
+              <div className="field">
+                <label htmlFor="timer-task">Task</label>
+                <select
+                  id="timer-task"
+                  value={selectedTaskId ?? ""}
+                  onChange={(event) => {
+                    const value = event.target.value;
+                    if (!value) {
+                      setSelectedTaskId(null);
+                      return;
+                    }
+                    const taskId = Number(value);
+                    setSelectedTaskId(taskId);
+                    const chosenTask = tasks.find((task) => task.id === taskId);
+                    if (chosenTask?.estimated_minutes) {
+                      setCustomMinutes(String(chosenTask.estimated_minutes));
+                    }
+                  }}
+                >
+                  <option value="">No task (just focus)</option>
+                  {tasks.map((task) => (
+                    <option key={task.id} value={task.id}>
+                      {task.title}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div className="field">
+                <label htmlFor="timer-minutes">Duration (minutes)</label>
+                <div className="timer-duration">
+                  <input
+                    id="timer-minutes"
+                    type="number"
+                    min={MIN_SESSION_MINUTES}
+                    max={MAX_SESSION_MINUTES}
+                    value={customMinutes}
+                    onChange={(event) => setCustomMinutes(event.target.value)}
+                  />
+                  <div className="duration-buttons">
+                    {[15, 25, 50].map((value) => (
+                      <button
+                        key={value}
+                        type="button"
+                        className="button ghost small"
+                        onClick={() => setCustomMinutes(String(value))}
+                      >
+                        {value}m
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              <button className="button primary" type="button" onClick={handleStartTimer}>
+                Start focus session
+              </button>
+              <p className="timer-hint">
+                Sessions shorter than {MIN_SESSION_MINUTES} minutes are rounded up so your tracking stays meaningful.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <section className="panel insights-panel">
+          <div className="panel-header">
+            <div>
+              <h2>Insights</h2>
+              <p className="panel-subtitle">Celebrate progress and keep your streak alive.</p>
+            </div>
+          </div>
+
+          {stats ? (
+            <div className="stats-grid">
+              <article className="stat">
+                <span className="stat-label">Focus minutes</span>
+                <strong className="stat-value">{stats.total_focus_minutes}</strong>
+                <span className="stat-hint">from {stats.total_sessions} sessions</span>
+              </article>
+              <article className="stat">
+                <span className="stat-label">Average session</span>
+                <strong className="stat-value">{stats.average_session_minutes.toFixed(1)}m</strong>
+                <span className="stat-hint">Longest {formatMinutesLabel(Math.round(stats.longest_session_minutes))}</span>
+              </article>
+              <article className="stat">
+                <span className="stat-label">Focus days</span>
+                <strong className="stat-value">{stats.focus_days}</strong>
+                <span className="stat-hint">Keep the streak growing</span>
+              </article>
+            </div>
+          ) : (
+            <p className="empty">Focus stats will appear once you've logged a session.</p>
+          )}
+
+          <div className="session-list">
+            <h3>Recent sessions</h3>
+            {recentSessions.length === 0 ? (
+              <p className="empty">No sessions yet — start one to fill this feed.</p>
+            ) : (
+              <ul>
+                {recentSessions.map((session) => {
+                  const minutes = Math.round(session.seconds / 60);
+                  return (
+                    <li key={session.id}>
+                      <div>
+                        <span className="session-duration">{minutes}m</span>
+                        <span className="session-task">{resolveTaskTitle(session.task_id)}</span>
+                      </div>
+                      <span className="session-time">{formatSessionTimestamp(session.created_at)}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        </section>
+      </div>
     </div>
   );
 }

--- a/frontend/client/src/index.css
+++ b/frontend/client/src/index.css
@@ -1,68 +1,46 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: "Inter", "Segoe UI", Roboto, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
+  color: #0f172a;
+  background-color: #eef2ff;
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
   min-height: 100vh;
+  background: radial-gradient(circle at top left, #e0e7ff 0%, #f8fafc 45%, #e2e8f0 100%);
+  color: inherit;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+button,
+input,
+textarea,
+select {
+  font: inherit;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: inherit;
 }


### PR DESCRIPTION
## Summary
- replace the FastAPI skeleton with task, focus-session, and stats endpoints backed by an in-memory store
- exercise the new backend with pytest coverage for task CRUD flows and session/statistics responses
- rebuild the React client into a full FocusPad dashboard with task management, focus timer, insights, and refreshed styling

## Testing
- python -m pytest -q
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cbf583c8048322821d22ecf54a3a6e